### PR TITLE
added instance type to master node

### DIFF
--- a/service/creator/request/aws/master.go
+++ b/service/creator/request/aws/master.go
@@ -1,0 +1,13 @@
+package aws
+
+// Master configures AWS-specific worker node settings.
+type Master struct {
+	InstanceType string `json:"instance_type"`
+}
+
+// DefaultMaster provides default MasterAWSSettings.
+func DefaultMaster() Master {
+	return Master{
+		InstanceType: "",
+	}
+}

--- a/service/creator/request/master.go
+++ b/service/creator/request/master.go
@@ -1,10 +1,15 @@
 package request
 
+import (
+	"github.com/giantswarm/kubernetesdclient/service/creator/request/aws"
+)
+
 // Master configures the Kubernetes master nodes.
 type Master struct {
-	CPU     CPU     `json:"cpu"`
-	Memory  Memory  `json:"memory"`
-	Storage Storage `json:"storage"`
+	CPU     CPU        `json:"cpu"`
+	Memory  Memory     `json:"memory"`
+	Storage Storage    `json:"storage"`
+	AWS     aws.Master `json:"aws"`
 }
 
 // DefaultMaster provides a default master configuration by best effort.
@@ -13,5 +18,6 @@ func DefaultMaster() Master {
 		CPU:     DefaultCPU(),
 		Memory:  DefaultMemory(),
 		Storage: DefaultStorage(),
+		AWS:     aws.DefaultMaster(),
 	}
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/api/issues/350. I forgot the master nodes. We sort out the default for them in cluster-service already, so we can simply propagate them and automate the way through. 