### PR TITLE
Pass full request when making patch requests.

### DIFF
--- a/service/updater/service.go
+++ b/service/updater/service.go
@@ -86,7 +86,7 @@ func (s *Service) Update(ctx context.Context, request Request) (*Response, error
 	}
 
 	s.Logger.Log("debug", fmt.Sprintf("sending PATCH request to %s", u.String()), "service", Name)
-	r, err := s.RestClient.R().SetBody(request.Cluster.Patch).SetResult(DefaultResponse()).Patch(u.String())
+	r, err := s.RestClient.R().SetBody(request).SetResult(DefaultResponse()).Patch(u.String())
 	if err != nil {
 		return nil, microerror.MaskAny(err)
 	}


### PR DESCRIPTION
Towards giantswarm/kubernetesd#220

This PR fixes the bug with passing the patch request to kuberenetesd when scaling workers. It should pass the whole request not just the patch.