### PR TITLE
Add ReleaseVersion to Request

### DIFF
--- a/service/creator/request.go
+++ b/service/creator/request.go
@@ -17,6 +17,7 @@ type Request struct {
 	Masters           []request.Master       `json:"masters,omitempty"`
 	Name              string                 `json:"name,omitempty"`
 	Owner             string                 `json:"owner,omitempty"`
+	ReleaseVersion    string                 `json:"release_version"`
 	Scaling           request.Scaling        `json:"scaling,omitempty"`
 	VersionBundles    []versionbundle.Bundle `json:"version_bundles,omitempty"`
 	Workers           []request.Worker       `json:"workers,omitempty"`
@@ -32,6 +33,7 @@ func DefaultRequest() Request {
 		Masters:           []request.Master{},
 		Name:              "",
 		Owner:             "",
+		ReleaseVersion:    "",
 		Scaling:           request.Scaling{},
 		VersionBundles:    []versionbundle.Bundle{},
 		Workers:           []request.Worker{},


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/8436

The ReleaseVersion value must be passed to `kubernetesd` from `cluster-service`. This adds the field to the Request